### PR TITLE
Illusion assist

### DIFF
--- a/src/main/java/component/IllusionAssistComponent.java
+++ b/src/main/java/component/IllusionAssistComponent.java
@@ -188,6 +188,15 @@ public class IllusionAssistComponent {
         }
     }
 
+    public float getTranslatedHeightmapHeight(int x, int y) {
+        synchronized (lock) {
+            float height = (getHeightmapValue(x, y) & 0x3FFF) / 256.0f;
+            if (flattenFloorActive && translateEnabled.get())
+                height -= getFloorHeight(x, y);
+            return height;
+        }
+    }
+
     private float translateZ(int x, int y, float z) { return (z - getFloorHeight(x, y)); }
 
     private float replaceZ(HPacket packet, int x, int y) {

--- a/src/main/java/component/IllusionAssistComponent.java
+++ b/src/main/java/component/IllusionAssistComponent.java
@@ -23,7 +23,6 @@ public class IllusionAssistComponent {
     private final Object lock = new Object();
 
     private final GBuildTools extension;
-    private final FloorState floorState;
 
     private final BooleanProperty flattenFloorEnabled = new SimpleBooleanProperty();
     private final BooleanProperty translateEnabled = new SimpleBooleanProperty();
@@ -37,9 +36,8 @@ public class IllusionAssistComponent {
     private final Map<Integer, EntityLocation> entityMap = new HashMap<>();
     private final Map<Integer, EntityLocation> itemMap = new HashMap<>();
 
-    public IllusionAssistComponent(GBuildTools extension, FloorState floorState) {
+    public IllusionAssistComponent(GBuildTools extension) {
         this.extension = extension;
-        this.floorState = floorState;
 
         translateEnabled.addListener(this::onTranslateEnabledChanged);
 

--- a/src/main/java/component/IllusionAssistComponent.java
+++ b/src/main/java/component/IllusionAssistComponent.java
@@ -1,0 +1,444 @@
+package component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javafx.beans.Observable;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import gearth.extensions.parsers.HStuff;
+import gearth.protocol.HMessage;
+import gearth.protocol.HPacket;
+import gearth.protocol.connection.HClient;
+
+import extension.GBuildTools;
+
+import javafx.util.Pair;
+import room.FloorState;
+
+public class IllusionAssistComponent {
+    private final Object lock = new Object();
+
+    private final GBuildTools extension;
+    private final FloorState floorState;
+
+    private final BooleanProperty flattenFloorEnabled = new SimpleBooleanProperty();
+    private final BooleanProperty translateEnabled = new SimpleBooleanProperty();
+
+    private boolean flattenFloorActive = true;
+
+    private int roomWidth, roomLength;
+    private short[][] heightmap;
+    private int[][] floorplan;
+
+    private final Map<Integer, EntityLocation> entityMap = new HashMap<>();
+    private final Map<Integer, EntityLocation> itemMap = new HashMap<>();
+
+    public IllusionAssistComponent(GBuildTools extension, FloorState floorState) {
+        this.extension = extension;
+        this.floorState = floorState;
+
+        translateEnabled.addListener(this::onTranslateEnabledChanged);
+
+        extension.onConnect(this::onConnect);
+    }
+
+    public BooleanProperty flattenFloorEnabledProperty() { return flattenFloorEnabled; }
+    public BooleanProperty translateEnabledProperty() { return translateEnabled; }
+
+    private void onTranslateEnabledChanged(Observable observable) {
+        if (!flattenFloorActive) return;
+
+        boolean translate = translateEnabled.get();
+
+        Map<Pair<Integer, Integer>, List<EntityLocation>> map = new HashMap<>();
+        synchronized (lock) {
+            for (EntityLocation loc : itemMap.values()) {
+                Pair<Integer, Integer> xy = new Pair<>(loc.x, loc.y);
+                List<EntityLocation> ls;
+                if (map.containsKey(xy))
+                    ls = map.get(xy);
+                else
+                    map.put(xy, ls = new ArrayList<>());
+                ls.add(loc);
+            }
+        }
+
+        for (int y = 0; y < roomLength; y++) {
+            for (int x = 0; x < roomWidth; x++) {
+                Pair<Integer, Integer> xy = new Pair<>(x, y);
+                if (!map.containsKey(xy)) continue;
+
+                List<EntityLocation> items = map.get(xy);
+
+                HPacket packet = new HPacket("SlideObjectBundle", HMessage.Direction.TOCLIENT);
+                packet.appendInt(x); packet.appendInt(y);
+                packet.appendInt(x); packet.appendInt(y);
+                packet.appendInt(items.size());
+                for (EntityLocation item : items) {
+                    packet.appendInt(item.identifier);
+
+                    float fromZ = item.z;
+                    float toZ = translateZ(item.x, item.y, fromZ);
+
+                    if (!translate) {
+                        float tmp = fromZ;
+                        fromZ = toZ;
+                        toZ = tmp;
+                    }
+
+                    packet.appendString(Double.toString(fromZ));
+                    packet.appendString(Double.toString(toZ));
+                }
+                packet.appendInt(-1);
+                extension.sendToClient(packet);
+            }
+        }
+
+        synchronized (lock) {
+            for (EntityLocation e : entityMap.values()) {
+                HPacket packet = new HPacket("SlideObjectBundle", HMessage.Direction.TOCLIENT);
+                packet.appendInt(e.x); packet.appendInt(e.y);
+                packet.appendInt(e.x); packet.appendInt(e.y);
+                packet.appendInt(0);
+                packet.appendInt(0);
+                packet.appendInt(2);
+                packet.appendInt(e.identifier);
+                float fromZ = e.z;
+                float toZ = translateZ(e.x, e.y, fromZ);
+                if (!translate) {
+                    float tmp = fromZ;
+                    fromZ = toZ;
+                    toZ = tmp;
+                }
+                packet.appendString(Double.toString(fromZ));
+                packet.appendString(Double.toString(toZ));
+                extension.sendToClient(packet);
+            }
+        }
+    }
+
+    private void onConnect(String s, int i, String s1, String s2, HClient hClient) {
+        extension.intercept(HMessage.Direction.TOCLIENT, "HeightMap", this::onHeightMap);
+        extension.intercept(HMessage.Direction.TOCLIENT, "FloorHeightMap", this::onFloorHeightMap);
+        extension.intercept(HMessage.Direction.TOCLIENT, "HeightMapUpdate", this::onHeightMapUpdate);
+        extension.intercept(HMessage.Direction.TOCLIENT, "Objects", this::onObjects);
+        extension.intercept(HMessage.Direction.TOCLIENT, "ObjectAdd", this::onFloorItemAddOrUpdate);
+        extension.intercept(HMessage.Direction.TOCLIENT, "ObjectUpdate", this::onFloorItemAddOrUpdate);
+        extension.intercept(HMessage.Direction.TOCLIENT, "SlideObjectBundle", this::onSlideObjectBundle);
+        extension.intercept(HMessage.Direction.TOCLIENT, "Users", this::onUsers);
+        extension.intercept(HMessage.Direction.TOCLIENT, "UserUpdate", this::onUserUpdate);
+    }
+
+    private float translateZ(int x, int y, float z) {
+        if (floorplan == null)
+            return z;
+
+        if (x < 0 || y < 0 || x >= roomWidth || y >= roomLength)
+            return 0;
+
+        return z - floorplan[y][x];
+    }
+
+    private float replaceZ(HPacket packet, int x, int y) {
+        int index = packet.getReadIndex();
+        float z = Float.parseFloat(packet.readString());
+        float translatedZ = translateZ(x, y, z);
+        packet.replaceString(index, Float.toString(translatedZ));
+        packet.setReadIndex(index);
+        packet.readString();
+        return z;
+    }
+
+    private short translateHeightmapZ(int x, int y, short value) {
+        float height = (value & 0x3FFF) / 256.0f;
+        height = translateZ(x, y, height);
+        value &= 0xC000;
+        value |= ((short)(height * 256.0f) & 0x3FFF);
+        return value;
+    }
+
+    private void onHeightMap(HMessage hMessage) {
+        flattenFloorActive = extension.buildToolsEnabled() && flattenFloorEnabled.get();
+
+        synchronized (lock) {
+            entityMap.clear();
+            itemMap.clear();
+        }
+
+        hMessage.setBlocked(flattenFloorActive);
+
+        HPacket packet = hMessage.getPacket();
+        roomWidth = packet.readInteger();
+        int tiles = packet.readInteger();
+        roomLength = tiles / roomWidth;
+
+        heightmap = new short[roomLength][roomWidth];
+        for (int y = 0; y < roomLength; y++) {
+            for (int x = 0; x < roomWidth; x++) {
+                heightmap[y][x] = packet.readShort();
+            }
+        }
+    }
+
+    private void onFloorHeightMap(HMessage hMessage) {
+        hMessage.setBlocked(flattenFloorActive);
+        HPacket packet = hMessage.getPacket();
+
+        boolean legacyWallScaling = packet.readBoolean();
+        int wallHeight = packet.readInteger(); // wall height
+        String map = packet.readString();
+        String[] rows = map.split("\r");
+
+        floorplan = new int[rows.length][rows[0].length()];
+        for (int y = 0; y < roomLength; y++) {
+            for (int x = 0; x < roomWidth; x++) {
+                char c = Character.toLowerCase(rows[y].charAt(x));
+                int height = -1;
+                if ('0' <= c && c <= '9') {
+                    height = c - '0';
+                } else if ('a' <= c && c <= 'z' && c != x) {
+                    height = 10 + (c - 'a');
+                }
+                floorplan[y][x] = height;
+            }
+        }
+
+        if (!flattenFloorActive) return;
+
+        HPacket translatedHeightmap = new HPacket("HeightMap", HMessage.Direction.TOCLIENT);
+        translatedHeightmap.appendInt(roomWidth);
+        translatedHeightmap.appendInt(roomWidth * roomLength);
+        for (int y = 0; y < roomLength; y++) {
+            for (int x = 0; x < roomWidth; x++) {
+                short value = translateHeightmapZ(x, y, heightmap[y][x]);
+                translatedHeightmap.appendShort(value);
+            }
+        }
+
+        HPacket translatedFloorplan = new HPacket("FloorHeightMap", HMessage.Direction.TOCLIENT);
+        translatedFloorplan.appendBoolean(legacyWallScaling);
+        translatedFloorplan.appendInt(wallHeight);
+        translatedFloorplan.appendString(map.replaceAll("(?i)[1-9a-wy-z]", "0"));
+
+        extension.sendToClient(translatedHeightmap);
+        extension.sendToClient(translatedFloorplan);
+    }
+
+    private void onHeightMapUpdate(HMessage hMessage) {
+        boolean translate = flattenFloorActive && translateEnabled.get();
+
+        HPacket packet = hMessage.getPacket();
+
+        int n = packet.readByte();
+        for (int i = 0; i < n; i++) {
+            int x = packet.readByte();
+            int y = packet.readByte();
+            short value = packet.readShort();
+            heightmap[y][x] = value;
+            if (translate) {
+                value = translateHeightmapZ(x, y, value);
+                packet.replaceShort(packet.getReadIndex() - 2, value);
+            }
+        }
+    }
+
+    private void onObjects(HMessage hMessage) {
+        boolean translate = flattenFloorActive && translateEnabled.get();
+
+        HPacket packet = hMessage.getPacket();
+
+        int n = packet.readInteger();
+        for (int i = 0; i < n; i++)
+            packet.skip("is");
+
+        n = packet.readInteger();
+        for (int i = 0; i < n; i++) {
+            int id = packet.readInteger();
+            packet.readInteger();
+            int x = packet.readInteger();
+            int y = packet.readInteger();
+            packet.readInteger();
+            float z;
+            if (translate) {
+                z = replaceZ(packet, x, y);
+            } else {
+                z = Float.parseFloat(packet.readString());
+            }
+            packet.skip("si");
+            int stuffDataType = packet.readInteger();
+            HStuff.readData(packet, stuffDataType);
+            packet.skip("iii");
+
+            synchronized (lock) {
+                EntityLocation loc = new EntityLocation(id, x, y, z);
+                itemMap.put(id, loc);
+            }
+        }
+    }
+
+    private void onFloorItemAddOrUpdate(HMessage hMessage) {
+        boolean translate = flattenFloorActive && translateEnabled.get();
+
+        HPacket packet = hMessage.getPacket();
+        int id = packet.readInteger();
+        packet.readInteger();
+        int x = packet.readInteger();
+        int y = packet.readInteger();
+        packet.readInteger();
+        float z;
+        if (translate) {
+            z = replaceZ(packet, x, y);
+        } else {
+            z = Float.parseFloat(packet.readString());
+        }
+
+        synchronized (lock) {
+            itemMap.put(id, new EntityLocation(id, x, y, z));
+        }
+    }
+
+    private void onSlideObjectBundle(HMessage hMessage) {
+        boolean translate = flattenFloorActive && translateEnabled.get();
+
+        HPacket packet = hMessage.getPacket();
+
+        int fromX = packet.readInteger();
+        int fromY = packet.readInteger();
+        int toX = packet.readInteger();
+        int toY = packet.readInteger();
+
+        int updates = packet.readInteger();
+        for (int i = 0; i < updates; i++) {
+            int id = packet.readInteger();
+            /*
+                using the offset at the toX/Y tile to translate fromZ gets rid of
+                visual glitching when floor items slide up & down stairs in the floor plan,
+                as the item jumps to the toX/Y tile height at the start of the slide.
+             */
+            float z;
+            if (translate) {
+                replaceZ(packet, toX, toY);
+                z = replaceZ(packet, toX, toY);
+            } else {
+                packet.readString();
+                z = Float.parseFloat(packet.readString());
+            }
+            synchronized (lock) {
+                itemMap.put(id, new EntityLocation(id, toX, toY, z));
+            }
+        }
+
+        int updateType = packet.readInteger();
+        if (updateType == 1 || updateType == 2) {
+            int index = packet.readInteger();
+            float z;
+            if (translate) {
+                replaceZ(packet, toX, toY);
+                z = replaceZ(packet, toX, toY);
+            } else {
+                packet.readString();
+                z = Float.parseFloat(packet.readString());
+            }
+            synchronized (lock) {
+                entityMap.put(index, new EntityLocation(index, toX, toY, z));
+            }
+        }
+    }
+
+    private void onUsers(HMessage hMessage) {
+        boolean translate = flattenFloorActive && translateEnabled.get();
+
+        HPacket packet = hMessage.getPacket();
+
+        int n = packet.readInteger();
+        for (int i = 0; i < n; i++) {
+            packet.skip("isss");
+            int index = packet.readInteger();
+            int x = packet.readInteger();
+            int y = packet.readInteger();
+            float z;
+            if (translate) {
+                z = replaceZ(packet, x, y);
+            } else {
+                z = Float.parseFloat(packet.readString());
+            }
+            synchronized (lock) {
+                entityMap.put(index, new EntityLocation(index, x, y, z));
+            }
+            packet.readInteger();
+            int type = packet.readInteger();
+            switch (type) {
+                case 1: packet.skip("siissib"); break;
+                case 2: packet.skip("iisibbbbbbis"); break;
+                case 4:
+                    packet.skip("sis");
+                    int count = packet.readInteger();
+                    for (int j = 0; j < count; j++)
+                        packet.readShort();
+                    break;
+                default: break;
+            }
+        }
+    }
+
+    private void onUserUpdate(HMessage hMessage) {
+        boolean translate = flattenFloorActive && translateEnabled.get();
+
+        HPacket packet = hMessage.getPacket();
+
+        int n = packet.readInteger();
+        for (int i = 0; i < n; i++) {
+            int index = packet.readInteger();
+            int x = packet.readInteger();
+            int y = packet.readInteger();
+            float z;
+            if (translate) {
+                z = replaceZ(packet, x, y);
+            } else {
+                z = Float.parseFloat(packet.readString());
+            }
+            synchronized (lock) {
+                entityMap.put(index, new EntityLocation(index, x, y, z));
+            }
+            packet.skip("ii");
+
+            int readIndex = packet.getReadIndex();
+            String status = packet.readString();
+            if (!translate) continue;
+
+            String[] parts = status.split("/");
+            for (int j = 0; j < parts.length; j++) {
+                String[] split = parts[j].split("\\s+");
+                if (split[0].equals("mv") && split.length > 1) {
+                    String[] tileSplit = split[1].split(",");
+                    int mvX = Integer.parseInt(tileSplit[0]);
+                    int mvY = Integer.parseInt(tileSplit[1]);
+                    float mvZ = Float.parseFloat(tileSplit[2]);
+                    tileSplit[2] = Float.toString(translateZ(mvX, mvY, mvZ));
+                    split[1] = String.join(",", tileSplit);
+                }
+                parts[j] = String.join(" ", split);
+            }
+            status = String.join("/", parts);
+            packet.replaceString(readIndex, status);
+            packet.setReadIndex(readIndex);
+            packet.readString();
+        }
+    }
+
+    static class EntityLocation {
+        public int identifier;
+        public int x, y;
+        public float z;
+        public EntityLocation(int identifier, int x, int y, float z) {
+            this.identifier = identifier;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+    }
+}

--- a/src/main/java/component/IllusionAssistComponent.java
+++ b/src/main/java/component/IllusionAssistComponent.java
@@ -69,6 +69,9 @@ public class IllusionAssistComponent {
 
         for (int y = 0; y < roomLength; y++) {
             for (int x = 0; x < roomWidth; x++) {
+                int h = getFloorHeight(x, y);
+                if (h <= 0) continue;
+
                 Pair<Integer, Integer> xy = new Pair<>(x, y);
                 if (!map.containsKey(xy)) continue;
 
@@ -82,7 +85,7 @@ public class IllusionAssistComponent {
                     packet.appendInt(item.identifier);
 
                     float fromZ = item.z;
-                    float toZ = translateZ(item.x, item.y, fromZ);
+                    float toZ = item.z - h;
 
                     if (!translate) {
                         float tmp = fromZ;
@@ -100,6 +103,8 @@ public class IllusionAssistComponent {
 
         synchronized (lock) {
             for (EntityLocation e : entityMap.values()) {
+                int h = getFloorHeight(e.x, e.y);
+                if (h <= 0) continue;
                 HPacket packet = new HPacket("SlideObjectBundle", HMessage.Direction.TOCLIENT);
                 packet.appendInt(e.x); packet.appendInt(e.y);
                 packet.appendInt(e.x); packet.appendInt(e.y);
@@ -108,7 +113,7 @@ public class IllusionAssistComponent {
                 packet.appendInt(2);
                 packet.appendInt(e.identifier);
                 float fromZ = e.z;
-                float toZ = translateZ(e.x, e.y, fromZ);
+                float toZ = e.z - h;
                 if (!translate) {
                     float tmp = fromZ;
                     fromZ = toZ;

--- a/src/main/java/extension/GBuildTools.java
+++ b/src/main/java/extension/GBuildTools.java
@@ -571,7 +571,7 @@ public class GBuildTools extends ExtensionForm {
             delayedFloorFurniDrop.add(dropInfo);
         }
 
-        double height = floorState.getTileHeight(dropInfo.getX(), dropInfo.getY());
+        double height = illusionAssist.getTranslatedHeightmapHeight(dropInfo.getX(), dropInfo.getY());
 
         if (override_rotation_cbx.isSelected()) {
             dropInfo.setRotation(override_rotation_spinner.getValue());

--- a/src/main/java/extension/GBuildTools.java
+++ b/src/main/java/extension/GBuildTools.java
@@ -10,7 +10,6 @@ import gearth.protocol.HPacket;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.scene.control.*;
-import javafx.scene.paint.Paint;
 import room.FloorState;
 import room.StackTileInfo;
 import room.StackTileSetting;
@@ -115,7 +114,7 @@ public class GBuildTools extends ExtensionForm {
 
     // illusion assist
     public CheckBox flatten_floor_cbx;
-    public CheckBox translate_z_cbx;
+    public CheckBox translate_heights_cbx;
 
     private static final int ratelimitStartOffset = 15;
 
@@ -329,7 +328,7 @@ public class GBuildTools extends ExtensionForm {
 
             // illusion assist
             flatten_floor_cbx.setDisable(!buildToolsEnabled());
-            translate_z_cbx.setDisable(!buildToolsEnabled());
+            translate_heights_cbx.setDisable(!buildToolsEnabled());
         });
     }
 
@@ -407,7 +406,7 @@ public class GBuildTools extends ExtensionForm {
         // illusion assist
         illusionAssist = new IllusionAssistComponent(this);
         illusionAssist.flattenFloorEnabledProperty().bind(flatten_floor_cbx.selectedProperty());
-        illusionAssist.translateEnabledProperty().bind(translate_z_cbx.selectedProperty());
+        illusionAssist.translateEnabledProperty().bind(translate_heights_cbx.selectedProperty());
 
         floorState.requestRoom(this);
 

--- a/src/main/java/extension/GBuildTools.java
+++ b/src/main/java/extension/GBuildTools.java
@@ -111,6 +111,10 @@ public class GBuildTools extends ExtensionForm {
     public CheckBox pickup_hide_cbx;
     public Button makevisibleBtn;
 
+    // illusion assist
+    public CheckBox flatten_floor_cbx;
+    public CheckBox translate_z_cbx;
+
     private static final int ratelimitStartOffset = 15;
 
 
@@ -321,6 +325,9 @@ public class GBuildTools extends ExtensionForm {
             pickup_hide_cbx.setDisable(!buildToolsEnabled()); // make sure you're not gonna pick up furni if gbuildtools not enabled
             makevisibleBtn.setDisable(!floorState.hasHiddenFurni());
 
+            // illusion assist
+            flatten_floor_cbx.setDisable(!buildToolsEnabled());
+            translate_z_cbx.setDisable(!buildToolsEnabled());
         });
     }
 

--- a/src/main/java/extension/GBuildTools.java
+++ b/src/main/java/extension/GBuildTools.java
@@ -405,7 +405,7 @@ public class GBuildTools extends ExtensionForm {
         intercept(HMessage.Direction.TOSERVER, "PickupObject", this::onPickUpItem);
 
         // illusion assist
-        illusionAssist = new IllusionAssistComponent(this, floorState);
+        illusionAssist = new IllusionAssistComponent(this);
         illusionAssist.flattenFloorEnabledProperty().bind(flatten_floor_cbx.selectedProperty());
         illusionAssist.translateEnabledProperty().bind(translate_z_cbx.selectedProperty());
 

--- a/src/main/java/extension/GBuildTools.java
+++ b/src/main/java/extension/GBuildTools.java
@@ -22,6 +22,8 @@ import utils.Wrapper;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import component.IllusionAssistComponent;
+
 @ExtensionInfo(
         Title =  "G-BuildTools",
         Description =  "For all your building needs",
@@ -150,8 +152,8 @@ public class GBuildTools extends ExtensionForm {
     // invis furni & black hole
     private volatile long latestReq = -1;
 
-
-
+    // illusion assist
+    private IllusionAssistComponent illusionAssist;
 
 
     public void onRotatedFurniClick(ActionEvent actionEvent) {
@@ -401,6 +403,11 @@ public class GBuildTools extends ExtensionForm {
 
         // hide furni
         intercept(HMessage.Direction.TOSERVER, "PickupObject", this::onPickUpItem);
+
+        // illusion assist
+        illusionAssist = new IllusionAssistComponent(this, floorState);
+        illusionAssist.flattenFloorEnabledProperty().bind(flatten_floor_cbx.selectedProperty());
+        illusionAssist.translateEnabledProperty().bind(translate_z_cbx.selectedProperty());
 
         floorState.requestRoom(this);
 

--- a/src/main/java/extension/GBuildTools.java
+++ b/src/main/java/extension/GBuildTools.java
@@ -206,7 +206,7 @@ public class GBuildTools extends ExtensionForm {
         primaryStage.sizeToScene();
     }
 
-    private boolean buildToolsEnabled() {
+    public boolean buildToolsEnabled() {
         return enable_gbuildtools.isSelected();
     }
     public boolean furniDataReady() {

--- a/src/main/java/extension/gbuildtools.fxml
+++ b/src/main/java/extension/gbuildtools.fxml
@@ -233,7 +233,7 @@
                                  </styleClass>
                               </Label>
                               <CheckBox fx:id="flatten_floor_cbx" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" text="Flatten floor plan" textFill="#000000d6" wrapText="true" />
-                              <CheckBox fx:id="translate_z_cbx" layoutX="14.0" layoutY="39.0" mnemonicParsing="false" text="Translate entity positions" />
+                              <CheckBox fx:id="translate_heights_cbx" layoutX="14.0" layoutY="39.0" mnemonicParsing="false" text="Translate heights" selected="true" />
                            </children>
                         </AnchorPane>
                      </children>

--- a/src/main/java/extension/gbuildtools.fxml
+++ b/src/main/java/extension/gbuildtools.fxml
@@ -232,7 +232,7 @@
                                     <String fx:value="themed-background" />
                                  </styleClass>
                               </Label>
-                              <CheckBox fx:id="flatten_floor_cbx" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#flattenFloorClick" text="Flatten floor plan" textFill="#000000d6" wrapText="true" />
+                              <CheckBox fx:id="flatten_floor_cbx" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" text="Flatten floor plan" textFill="#000000d6" wrapText="true" />
                               <CheckBox fx:id="translate_z_cbx" layoutX="14.0" layoutY="39.0" mnemonicParsing="false" text="Translate entity positions" />
                            </children>
                         </AnchorPane>

--- a/src/main/java/extension/gbuildtools.fxml
+++ b/src/main/java/extension/gbuildtools.fxml
@@ -224,6 +224,18 @@
                               <Button fx:id="makevisibleBtn" disable="true" layoutX="12.0" layoutY="37.0" mnemonicParsing="false" onAction="#makeVisibleClick" text="Make furni visible again" />
                            </children>
                         </AnchorPane>
+                        <AnchorPane layoutX="231.0" layoutY="14.0" prefHeight="77.0" prefWidth="200.0" style="-fx-border-color: grey; -fx-border-radius: 3px;">
+                           <children>
+                              <Label layoutX="65.0" layoutY="-8.0" text="Illusion assist">
+                                 <styleClass>
+                                    <String fx:value="softer" />
+                                    <String fx:value="themed-background" />
+                                 </styleClass>
+                              </Label>
+                              <CheckBox fx:id="flatten_floor_cbx" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#flattenFloorClick" text="Flatten floor plan" textFill="#000000d6" wrapText="true" />
+                              <CheckBox fx:id="translate_z_cbx" layoutX="14.0" layoutY="39.0" mnemonicParsing="false" text="Translate entity positions" />
+                           </children>
+                        </AnchorPane>
                      </children>
                  </AnchorPane>
               </content>


### PR DESCRIPTION
Implement #17.
Flattens all tiles in the floor plan upon entering a room while enabled.
Allows the user to toggle height translation on/off.
When height translation is on, locations are negatively offset to the flattened floor tile.
Otherwise floor items/entities appear at their usual, unflattened locations (some wall items may still appear in the wrong locations due to the flattened floorplan changing the base wall height offset).